### PR TITLE
Fix Debian version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ $ scp `<VPS username>`@`<VPS ip address>`:~/hoprd-logs.txt ~/
 | OS     | version | works |
 | ------ | ------- | ----- |
 | ubuntu | 16.04.1 | ✔️    |
-| debian | 4.19    | ✔️    |
+| debian | 10 (buster) | ✔️    |
 | macOS (x86)  | 10.15.7 | ✔️    |
 | macOS (ARM)  | 10.15.7 | ✔️    |
 


### PR DESCRIPTION
There is no such thing as Debian 4.19. The intent here is clearly Debian 10 (Debian Buster) which comes with version 4.19 of the kernel.